### PR TITLE
NTI-4189: Course Overview Groups headers hidden

### DIFF
--- a/src/main/js/course/components/widgets/Group.scss
+++ b/src/main/js/course/components/widgets/Group.scss
@@ -1,6 +1,5 @@
 .course-overview-group {
 	position: relative;
-	overflow: hidden;
 	border: none;
 	padding: 0 0.5rem;
 	margin: 1.125rem -0.5rem;


### PR DESCRIPTION
This changed with iOS 11. The legend of the fieldset was outside the height of the fieldset and being hidden.