### PR TITLE
NTI-4620: make sure pre tags don't wrap.

### DIFF
--- a/src/main/js/content/components/Content.scss
+++ b/src/main/js/content/components/Content.scss
@@ -97,6 +97,8 @@ nti\:content {
 		padding-left: 4ex;
 		overflow: auto;
 		word-wrap: normal;
+		word-break: normal;
+		white-space: pre;
 		-webkit-overflow-scrolling: touch;
 
 		&.code .ln {


### PR DESCRIPTION
This will need another change where we make sure you can't add styles to codeblocks. That change won't occur here. 