### PR TITLE
NTI-4705: Protect against empty content package

### DIFF
--- a/src/main/js/content/Actions.js
+++ b/src/main/js/content/Actions.js
@@ -40,6 +40,10 @@ export function loadPage (ntiid, context, extra) {
 	}
 
 	function loadTOC (id) {
+		if (!id || id === 'placeholder') {
+			return null;
+		}
+
 		return loadPackage(id)
 			.then(p => (p && p.getTableOfContents()) || Promise.reject('No Package for Page!'));
 	}

--- a/src/main/js/content/PageDescriptor.js
+++ b/src/main/js/content/PageDescriptor.js
@@ -43,7 +43,10 @@ export default class PageDescriptor {
 	}
 
 
-	getPageSource (id) { return this.tableOfContents.getPageSource(id); }
+	getPageSource (id) {
+		const toc = this.tableOfContents;
+		return toc && toc.getPageSource(id); 
+	}
 
 
 	getPageStyles () { return this.styles; }

--- a/src/main/js/content/components/viewer-parts/interaction.js
+++ b/src/main/js/content/components/viewer-parts/interaction.js
@@ -80,11 +80,12 @@ export default {
 			if (isNTIID(id)) {
 				let {pageSource, page} = this.state;
 				let ref = encodeForURI(id);
+				const toc = page.getTableOfContents();
 
 				href = pageSource.contains(id)
 					? this.makeHref(ref) //the ID is in the pageSource... just page
 					//ID is not in the pageSource, reroot:
-					: page.getTableOfContents().getNode(id) != null
+					: (toc && toc.getNode(id) != null)
 						? this.makeHrefNewRoot(ref)
 						//ID is not in the current toc, resolve:
 						: this.makeObjectHref(ref);

--- a/src/main/js/content/page-generators/AssessmentPageGenerator.js
+++ b/src/main/js/content/page-generators/AssessmentPageGenerator.js
@@ -8,7 +8,11 @@ export function buildPageInfoForContents (service, context, assessment, contents
 	const parent = assessment.parent('ContentPackageBundle');
 	const Bundle = parent && parent.ContentPackageBundle;
 	const Package = Bundle && Bundle.ContentPackages[0];
-	const ContentPackageNTIID = Package && Package.NTIID;
+	/*
+	* NTI-4705: Placeholder is there for courses that are newly created with no content packages.
+	* This allows for assignments to be opened in an empty course.
+	*/
+	const ContentPackageNTIID = (Package && Package.NTIID) || 'placeholder' ;
 
 	const content = `
 		<head>


### PR DESCRIPTION
Allows for assignments to be opened in empty courses.