### PR TITLE
Be specific because of the * on a parent element

### DIFF
--- a/src/main/js/content/components/Content.scss
+++ b/src/main/js/content/components/Content.scss
@@ -159,8 +159,10 @@ nti\:content {
 			line-height: 1em;
 			overflow: scroll;
 			margin-bottom: 10px;
+			word-wrap: normal;
+			word-break: normal;
 
-			* {
+			span {
 				word-wrap: normal;
 				word-break: normal;
 			}


### PR DESCRIPTION
Safari fixes, continues to work on chrome and firefox