### PR TITLE
share with available on first try

### DIFF
--- a/src/main/js/content/components/discussions/NoteEditor.jsx
+++ b/src/main/js/content/components/discussions/NoteEditor.jsx
@@ -52,9 +52,9 @@ export default class NoteEditor extends React.Component {
 	get canEditSharing () {
 		const {item} = this.props;
 
-		if (!item) { return false; }
+		if (!item) { return true; }
 
-		if (!item.isModifiable) { return true; }
+		if (!item.isModifiable) { return false; }
 
 		const refCount = item.ReferencedByCount;
 


### PR DESCRIPTION
canEditSharing was being passed to a readOnly function, which seemed backwards to me